### PR TITLE
Bugfix for 1D arrays to parse shapes like (n,)

### DIFF
--- a/fastnumpyio.py
+++ b/fastnumpyio.py
@@ -23,7 +23,7 @@ def load(file):
     if not header:
         return None
     descr = str(header[19:25], 'utf-8').replace("'","").replace(" ","")
-    shape = tuple(int(num) for num in str(header[60:120], 'utf-8').replace(', }', '').replace('(', '').replace(')', '').split(','))
+    shape = tuple(int(num) for num in str(header[60:120], 'utf-8').replace(',)', ')').replace(', }', '').replace('(', '').replace(')', '').split(','))
     datasize = numpy.lib.format.descr_to_dtype(descr).itemsize
     for dimension in shape:
         datasize *= dimension


### PR DESCRIPTION
In `load`, added `replace(',)', ')')` to `shape` string before splitting to handle 1-tuple shapes like `(n,)`.  For instance, with array: `np.ones(10000000)`

## Without PR code, shape parsing fails:

```python
# str(header[60:120], 'utf-8')
header = '(10000000,), }                                              '
# ValueError: invalid literal for int() with base 10: '                                              '
shape = tuple(map(int, header.replace(', }', '').replace('(', '').replace(')', '').split(',')))
```

## With PR code, shape parsing succeeds:

```python
# str(header[60:120], 'utf-8')
header = '(10000000,), }                                              '
shape = tuple(map(int, header.replace(',)', ')').replace(', }', '').replace('(', '').replace(')', '').split(',')))
#                            ^^^^^^^^^^^^^^^^^^^
#                                ONLY CHANGE
assert shape == (10000000,)
```


(Thank you for creating this repo, by the way.)